### PR TITLE
Improve edit shift button layout

### DIFF
--- a/admin/edit_single_shift.php
+++ b/admin/edit_single_shift.php
@@ -301,8 +301,8 @@ require_once '../includes/header.php';
                       placeholder="Залиште порожнім, якщо не застосовно"><?php echo escape($input_data['manual_close_comment'] ?? ''); ?></textarea>
         </div>
 
-        <div class="flex items-center justify-end space-x-3 pt-4 border-t border-gray-200/50 mt-6">
-            <a href="<?php echo htmlspecialchars($_SESSION['previous_page'] ?? 'manage_shifts.php'); ?>" class="btn-secondary">Скасувати</a>
+        <div class="flex items-center justify-between pt-4 border-t border-gray-200/50 mt-6">
+            <a href="<?php echo htmlspecialchars($_SESSION['previous_page'] ?? 'manage_shifts.php'); ?>" class="btn-red">Скасувати</a>
             <button type="submit" class="btn-green">
                 <i class="fas fa-save mr-2"></i> Зберегти Зміни
             </button>


### PR DESCRIPTION
## Summary
- Separate cancel and save actions in shift edit form with clearer layout
- Style cancel button in red and align it to the left for better UX

## Testing
- `php -l admin/edit_single_shift.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8ef3bfc348322b5e3dfdd28b6ab1d