### PR TITLE
Fix sticky footer and login layout

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -211,6 +211,7 @@ if (!function_exists('get_role_name_ukrainian')) {
             padding-left: var(--safe-area-inset-left);
             padding-right: var(--safe-area-inset-right);
             padding-bottom: 2px;
+            margin-top: auto; /* Додає відступ зверху, щоб футер прилипав до низу */
         }
 
         /* Адаптация для iOS с "монобровью" */

--- a/login.php
+++ b/login.php
@@ -61,7 +61,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 require_once 'includes/header.php';
 ?>
 
-<div class="flex items-center justify-center py-10 px-4 sm:px-6 lg:px-8 text-white" style="min-height: calc(100vh - 160px);">
+<main class="flex items-center justify-center py-10 px-4 sm:px-6 lg:px-8 text-white">
     <div class="max-w-md w-full space-y-6 glass-effect p-6 sm:p-8">
         <div>
             <h2 class="mt-4 text-center text-2xl sm:text-3xl font-bold text-white">
@@ -109,7 +109,7 @@ require_once 'includes/header.php';
             </p>
         </form>
     </div>
-</div>
+</main>
 
 <?php require_once 'includes/footer.php'; ?>
 </body>


### PR DESCRIPTION
## Summary
- Make footer stick to bottom of viewport without covering content
- Use `<main>` in login page so content fills available height

## Testing
- `php -l login.php`
- `php -l includes/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8f5a3b6988322980c2e8c6b34e383