### PR TITLE
Fix mobile overflow of lifeguard stats cards

### DIFF
--- a/includes/lifeguard_panel.php
+++ b/includes/lifeguard_panel.php
@@ -166,6 +166,7 @@ if (!function_exists('format_datetime')) {
             box-shadow: 0 4px 16px rgba(0, 0, 0, 0.05);
             transition: all 0.3s ease;
             padding: 1.25rem;
+            min-width: 0;
         }
         
         .stat-card:hover {
@@ -186,21 +187,21 @@ if (!function_exists('format_datetime')) {
 
         @media (max-width: 640px) {
             .stats-grid {
-                grid-template-columns: repeat(3, 1fr);
+                grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
             }
-            
+
             .stat-card {
                 padding: 1rem;
             }
-            
+
             .stat-card i {
                 font-size: 1.25rem;
             }
-            
+
             .stat-card h4 {
                 font-size: 0.875rem;
             }
-            
+
             .stat-card p {
                 font-size: 0.75rem;
             }


### PR DESCRIPTION
## Summary
- prevent stat cards from overflowing the container on small screens
- allow cards to shrink and wrap using auto-fit grid columns and min-width

## Testing
- `php -l includes/lifeguard_panel.php`
- `npm test` (fails: Missing script: "test")
- `composer test` (fails: Command "test" is not defined.)

------
https://chatgpt.com/codex/tasks/task_e_68a8f5ea07dc832298a5e2be91e03720