### PR TITLE
Ensure director panel displays default tab on load

### DIFF
--- a/includes/director_panel.php
+++ b/includes/director_panel.php
@@ -15,20 +15,20 @@ require_role('director');
         <nav aria-label="Панель директора">
             <ul class="-mb-px flex flex-wrap space-x-1 sm:space-x-2" id="directorTab" role="tablist">
                 <li role="presentation">
-                    <button class="director-tab-button" id="director-posts-tab" type="button" onclick="showDirectorTab('posts')" aria-selected="true">Сітка Постів</button>
+                    <button class="director-tab-button px-4 py-2 text-sm font-medium rounded-t-lg focus:outline-none" id="director-posts-tab" type="button" onclick="showDirectorTab('posts')" aria-selected="true">Сітка Постів</button>
                 </li>
                 <li role="presentation">
-                    <button class="director-tab-button" id="director-analytics-tab" type="button" onclick="showDirectorTab('analytics')" aria-selected="false">Комплексна аналітика</button>
+                    <button class="director-tab-button px-4 py-2 text-sm font-medium rounded-t-lg focus:outline-none" id="director-analytics-tab" type="button" onclick="showDirectorTab('analytics')" aria-selected="false">Комплексна аналітика</button>
                 </li>
                 <li role="presentation">
-                    <button class="director-tab-button" id="director-rating-tab" type="button" onclick="showDirectorTab('rating')" aria-selected="false">Рейтинг</button>
+                    <button class="director-tab-button px-4 py-2 text-sm font-medium rounded-t-lg focus:outline-none" id="director-rating-tab" type="button" onclick="showDirectorTab('rating')" aria-selected="false">Рейтинг</button>
                 </li>
             </ul>
         </nav>
     </div>
 
     <div id="directorTabContent">
-    <div class="director-tab-content" id="director-posts-content" role="tabpanel">
+    <div class="director-tab-content block" id="director-posts-content" role="tabpanel">
         <?php require __DIR__ . '/panels/director_post_grid.php'; ?>
     </div>
     <div class="director-tab-content hidden" id="director-analytics-content" role="tabpanel">

--- a/js/app.js
+++ b/js/app.js
@@ -522,6 +522,38 @@ function initializeDynamicContent() {
         
         showAdminTab(initialAdminTab);
     }
+
+    // --- Ініціалізація Вкладок Панелі Директора ---
+    if (document.getElementById('directorTabContent') && typeof showDirectorTab === 'function') {
+        const hash = window.location.hash;
+        const urlParams = new URLSearchParams(window.location.search);
+
+        const validDirectorTabs = ['posts', 'analytics', 'rating'];
+        let initialDirectorTab = 'posts';
+
+        if (hash.startsWith('#director-')) {
+            const tabFromHash = hash.substring(10);
+            if (validDirectorTabs.includes(tabFromHash)) {
+                initialDirectorTab = tabFromHash;
+            }
+        } else {
+            const tabFromGet = urlParams.get('tab_director');
+            if (tabFromGet && validDirectorTabs.includes(tabFromGet)) {
+                initialDirectorTab = tabFromGet;
+            }
+        }
+
+        const allDirectorTabs = ['director-posts-content', 'director-analytics-content', 'director-rating-content'];
+        allDirectorTabs.forEach(tabId => {
+            const tab = document.getElementById(tabId);
+            if (tab) {
+                tab.classList.add('hidden');
+                tab.style.display = 'none';
+            }
+        });
+
+        showDirectorTab(initialDirectorTab);
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Initialize Director panel tabs on page load with URL hash/param support
- Style Director tab buttons and show posts tab by default for smoother UX

## Testing
- `npm test` *(fails: Missing script "test")*
- `php -l includes/director_panel.php`
- `node --check js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a9006239dc8322ba537eeaa56bd79b