### PR TITLE
Ensure posts analytics filter uses tab_admin parameter

### DIFF
--- a/includes/panels/admin_posts_analytics_content.php
+++ b/includes/panels/admin_posts_analytics_content.php
@@ -222,7 +222,7 @@ $visitors_chart = ['labels' => array_column($visitor_stats_per_post, 'name'), 'b
                 </p>
             </div>
             <form action="#analytics-container" method="get" class="flex flex-wrap items-center gap-2" id="analyticsPeriodForm">
-                <input type="hidden" name="tab" value="posts-analytics">
+                <input type="hidden" name="tab_admin" value="posts-analytics">
                 <select name="period_type" id="period_type_selector" class="form-select text-sm rounded-lg border-gray-300 shadow-sm">
                     <option value="today" <?php echo ($selected_period_type === 'today') ? 'selected' : ''; ?>>Сьогодні</option>
                     <option value="week" <?php echo ($selected_period_type === 'week') ? 'selected' : ''; ?>>Цей тиждень</option>

--- a/js/app.js
+++ b/js/app.js
@@ -497,9 +497,9 @@ function initializeDynamicContent() {
                 initialAdminTab = tabNameFromHash;
             }
         } 
-        // 2. Якщо хеша немає, перевіряємо GET-параметр (tab_admin=...)
+        // 2. Якщо хеша немає, перевіряємо GET-параметри (tab_admin або tab)
         else {
-            const tabFromGet = urlParams.get('tab_admin');
+            const tabFromGet = urlParams.get('tab_admin') || urlParams.get('tab');
             if (tabFromGet && validAdminTabs.includes(tabFromGet)) {
                 initialAdminTab = tabFromGet;
             }


### PR DESCRIPTION
## Summary
- replace hidden `tab` field with `tab_admin` in posts analytics filter
- allow `js/app.js` to read either `tab_admin` or `tab` query parameter

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b88ab06a208322956ba8bf88e35097